### PR TITLE
Fixes #3 - use the username as default bucket name

### DIFF
--- a/feed_dcp.go
+++ b/feed_dcp.go
@@ -176,6 +176,12 @@ func NewDCPFeed(name, indexName, url, poolName,
 	}
 
 	var auth couchbase.AuthHandler
+
+	// if no auth username was provided, use the bucket name as the username
+	if params.AuthUser == "" {
+		params.AuthUser = bucketName
+	}
+
 	if params.AuthUser != "" {
 		auth = params
 	}


### PR DESCRIPTION
- if no auth username was provided, use the bucket name as the username
